### PR TITLE
Implemented Mask Swapping

### DIFF
--- a/Source/RWPaintingTool/RWPaintingTool/PaintingTool_Right.cs
+++ b/Source/RWPaintingTool/RWPaintingTool/PaintingTool_Right.cs
@@ -11,9 +11,14 @@ namespace RWPaintingTool
 {
     public partial class PaintingTool
     {
+
         private void DrawRightRect(Rect inRect)
         {
+            if (_thing == null || _thing.def == null) return;
+
             inRect.SplitHorizontally(ButSize.y, out var applyButtonRect, out inRect);
+
+            // Draw reset buttons
             if (Widgets.ButtonText(applyButtonRect.LeftPart(2f / 3f), "Reset".Translate()))
             {
                 ColorTracker.TempColorSet = ColorTracker.ColorSet;
@@ -24,13 +29,98 @@ namespace RWPaintingTool
                 _colorPicker.SetColors(ColorTracker.ColorSet[_curColorIndex]);
             }
 
-            inRect.SplitHorizontally(ButSize.y, out var masksRect, out var colorToolRect);
-
-
+            inRect.SplitHorizontally(ButSize.y, out var masksRect, out inRect);
             DrawMaskEditableColors(masksRect, _thing as Apparel);
+
+            inRect.SplitHorizontally(ColorPicker.DefaultSize.y, out var colorToolRect, out var maskSelectionRect);
             DrawColorTool(colorToolRect);
 
+            var paintableExt = _thing.def.GetModExtension<PaintableExtension>();
+            if (paintableExt?.maskCount > 0)
+            {
+                DrawMaskSelection(maskSelectionRect, paintableExt);
+            }
         }
+
+        private void DrawMaskSelection(Rect rect, PaintableExtension ext)
+        {
+            var maskTracker = ColorTrackerDB.GetMaskTracker(_thing);
+            if (maskTracker == null || !(_thing is Apparel apparel)) return;
+            if (!ApparelGraphicRecordGetter.TryGetGraphicApparel(apparel, pawn?.story?.bodyType, out var baseRecord)) return;
+
+            float rowHeight = 60f;
+            float spacing = 5f;
+            float buttonWidth = 40f;
+            float previewSize = rowHeight;
+
+            Rect rowRect = new Rect(rect.x, rect.y, rect.width, rowHeight);
+            int originalMaskID = maskTracker.CurMaskID;
+
+            for (int i = 0; i < ext.maskCount; i++)
+            {
+                if (rowRect.yMax > rect.yMax) break;
+
+                var buttonRect = new Rect(rowRect.x, rowRect.y, buttonWidth, rowHeight);
+                var previewRect = new Rect(buttonRect.xMax + spacing, rowRect.y, previewSize, previewSize);
+
+                bool isSelected = i == originalMaskID;
+                if (isSelected)
+                    Widgets.DrawHighlightSelected(rowRect);
+                else if (Mouse.IsOver(rowRect))
+                    Widgets.DrawHighlight(rowRect);
+
+                if (Widgets.ButtonText(buttonRect, i.ToString()))
+                {
+                    maskTracker.SetMaskID(i);
+                    UpdateCurrentMaskWithTracker();
+                    originalMaskID = i;
+                }
+
+                int prevMaskID = maskTracker.CurMaskID;
+
+                maskTracker.SetMaskID(i);
+                if (ApparelGraphicRecordGetter.TryGetGraphicApparel(apparel, pawn?.story?.bodyType, out var graphicRecord))
+                {
+                    maskTracker.SetMaskOn(graphicRecord.graphic);
+                    GraphicsPatches.CurThing = _thing;
+                    var mat = graphicRecord.graphic.MatAt(rotation);
+                    GenUI.DrawTextureWithMaterial(previewRect.Rounded(), mat.mainTexture, mat);
+                    GraphicsPatches.CurThing = null;
+                }
+
+                maskTracker.SetMaskID(prevMaskID);
+                UpdateCurrentMaskWithTracker();
+
+                rowRect.y += rowHeight + spacing;
+            }
+        }
+
+        private void UpdateCurrentMaskWithTracker()
+        {
+            if (_thing == null) return;
+
+            var maskTracker = ColorTrackerDB.GetMaskTracker(_thing);
+            if (maskTracker == null) return;
+
+            if (_thing is Apparel apparel)
+            {
+                if (ApparelGraphicRecordGetter.TryGetGraphicApparel(apparel, apparel.Wearer?.story?.bodyType, out var graphicRecord))
+                {
+                    maskTracker.SetMaskOn(graphicRecord.graphic);
+                    apparel.Notify_ColorChanged();
+                }
+            }
+            else
+            {
+                Graphic graphic = _thing.Graphic;
+                if (graphic != null)
+                {
+                    maskTracker.SetMaskOn(graphic);
+                    _thing.DirtyMapMesh(_thing.Map);
+                }
+            }
+        }
+
         private void DrawColorTool(Rect rect)
         {
 


### PR DESCRIPTION
Implemented a WIP version of the mask swapping. UI still needs to be ironed out a little bit, but the core functionality is there.
Usage:
XML - Simply set the mask count to however many masks you have. 
Textures : Increase the name of the mask to the next one up. So 8_Male_Mask0_south, 8_Male_Mask1_south, 8_Male_Mask2_south and so on. 